### PR TITLE
LUGG-1055 Added editing for content editors

### DIFF
--- a/luggage_bean_menu.features.user_permission.inc
+++ b/luggage_bean_menu.features.user_permission.inc
@@ -33,6 +33,7 @@ function luggage_bean_menu_user_default_permissions() {
     'name' => 'edit any menu bean',
     'roles' => array(
       'bean editor' => 'bean editor',
+      'content editor' => 'content editor',
     ),
     'module' => 'bean',
   );

--- a/luggage_bean_menu.info
+++ b/luggage_bean_menu.info
@@ -9,6 +9,7 @@ dependencies[] = ctools
 dependencies[] = features
 dependencies[] = link
 dependencies[] = list
+dependencies[] = luggage_roles
 dependencies[] = options
 features[bean_type][] = menu
 features[ctools][] = bean_admin_ui:bean:5


### PR DESCRIPTION
Changes luggage_bean_menu to require luggage_roles so that we can add editing permissions for content editor.