### PR TITLE
NREM-250 Active class applied with relative url is used

### DIFF
--- a/js/luggage_bean_menu.js
+++ b/js/luggage_bean_menu.js
@@ -3,9 +3,10 @@
 $(document).ready(function() {
 
   $(function() {
-    var currentUrl = window.location.href;
-    currentUrl = currentUrl.replace(/#/, "");
-    $('nav.bean-menu a[href|="' + currentUrl + '"]').addClass('active');
+    var url = window.location.href;
+    var slug = url.split('/').reverse()[0];
+    slug = slug.replace(/#/, "");
+    $('nav.bean-menu a[href|="' + slug + '"]').addClass('active');
   });
 
 });


### PR DESCRIPTION
We should now be able to use just the relative path as the url, and the javascript with pick it up and apply the .active class.

You can still use both static and relative paths, but the .active class now works for relative.