### PR TITLE
BCB-36 Add gear icon and content editor permissions. Major

### DIFF
--- a/luggage_bean_menu.features.user_permission.inc
+++ b/luggage_bean_menu.features.user_permission.inc
@@ -33,6 +33,7 @@ function luggage_bean_menu_user_default_permissions() {
     'name' => 'edit any menu bean',
     'roles' => array(
       'bean editor' => 'bean editor',
+      'content editor' => 'content editor',
     ),
     'module' => 'bean',
   );

--- a/luggage_bean_menu.info
+++ b/luggage_bean_menu.info
@@ -9,6 +9,7 @@ dependencies[] = ctools
 dependencies[] = features
 dependencies[] = link
 dependencies[] = list
+dependencies[] = luggage_roles
 dependencies[] = options
 features[bean_type][] = menu
 features[ctools][] = bean_admin_ui:bean:5

--- a/templates/bean--menu.tpl.php
+++ b/templates/bean--menu.tpl.php
@@ -1,4 +1,7 @@
 <nav role="navigation" class="bean-menu <?php print $bean->field_menu_orientation['und'][0]['value'] ?>">
+
+  <?php print render($title_suffix) ?>
+  
   <?php if ($bean->field_menu_link) :?>
     <ul>
       <?php $items = field_get_items('bean', $bean, 'field_menu_link');


### PR DESCRIPTION
Adds the gear icon into the template. Without this, there's no way for content editors to edit their beans.